### PR TITLE
Removing write_private and read_private scopes as per the Pinterest p…

### DIFF
--- a/app/src/main/java/com/pinterest/android/pinsdk/MainActivity.java
+++ b/app/src/main/java/com/pinterest/android/pinsdk/MainActivity.java
@@ -47,8 +47,6 @@ public class MainActivity extends ActionBarActivity implements View.OnClickListe
         scopes.add(PDKClient.PDKCLIENT_PERMISSION_WRITE_PUBLIC);
         scopes.add(PDKClient.PDKCLIENT_PERMISSION_READ_RELATIONSHIPS);
         scopes.add(PDKClient.PDKCLIENT_PERMISSION_WRITE_RELATIONSHIPS);
-        scopes.add(PDKClient.PDKCLIENT_PERMISSION_READ_PRIVATE);
-        scopes.add(PDKClient.PDKCLIENT_PERMISSION_WRITE_PRIVATE);
 
         pdkClient.login(this, scopes, new PDKCallback() {
             @Override

--- a/pdk/src/main/java/com/pinterest/android/pdk/PDKClient.java
+++ b/pdk/src/main/java/com/pinterest/android/pdk/PDKClient.java
@@ -34,8 +34,6 @@ public class PDKClient {
 
     public static final String PDKCLIENT_PERMISSION_READ_PUBLIC = "read_public";
     public static final String PDKCLIENT_PERMISSION_WRITE_PUBLIC = "write_public";
-    public static final String PDKCLIENT_PERMISSION_READ_PRIVATE = "read_private";
-    public static final String PDKCLIENT_PERMISSION_WRITE_PRIVATE = "write_private";
     public static final String PDKCLIENT_PERMISSION_READ_RELATIONSHIPS = "read_relationships";
     public static final String PDKCLIENT_PERMISSION_WRITE_RELATIONSHIPS = "write_relationships";
 


### PR DESCRIPTION
…olicy.

Tested by running the sample app, and confirmed the oauth screen doesn't mention private scopes, and my boards view no longer shows any secret boards. Screenshots attached.

![screen shot 2016-06-23 at 10 07 08 am](https://cloud.githubusercontent.com/assets/5110564/16312749/fdacd2e6-392a-11e6-8b1a-2c78aacc5e6f.png)

![screen shot 2016-06-23 at 10 07 22 am](https://cloud.githubusercontent.com/assets/5110564/16312752/fec5252a-392a-11e6-81d1-b20f3be394bb.png)
