### PR TITLE
remove unnecessary manifest settings

### DIFF
--- a/pdk/src/main/AndroidManifest.xml
+++ b/pdk/src/main/AndroidManifest.xml
@@ -1,10 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.pinterest.android.pdk">
-
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-        >
-
-    </application>
+<manifest package="com.pinterest.android.pdk">
 
 </manifest>


### PR DESCRIPTION
If exist 'android:allowBackup="true"', this attribute is always added to main project manifest.
If exist 'android:label="@string/app_name"', main project may need 'tools:replace="android:label"' attribute.
