### PR TITLE
Added getter for _isAuthenticated field

### DIFF
--- a/pdk/src/main/java/com/pinterest/android/pdk/PDKClient.java
+++ b/pdk/src/main/java/com/pinterest/android/pdk/PDKClient.java
@@ -129,11 +129,6 @@ public class PDKClient {
         PDKClient._debugMode = debugMode;
     }
 
-
-    // ================================================================================
-    // API Interface
-    // ================================================================================
-
     /**
      * Set Oauth Access token
      */
@@ -150,6 +145,15 @@ public class PDKClient {
     public String getAccessToken() {
         return _accessToken;
     }
+
+    /**
+     * Let the caller application to know if it is authenticated.
+     */
+    public static boolean isAuthenticated() { return _isAuthenticated; }
+
+    // ================================================================================
+    // API Interface
+    // ================================================================================
 
     public void logout() {
         _accessToken = null;


### PR DESCRIPTION
Hi, this is a simple change, I've just added a getter to the _isAuthenticated field because I think that the SDK should expose it to let the application know if it's already authorized. Also, I've moved the setter and getter for the access token to the `Getters/Setters` block because I think they should be placed there.